### PR TITLE
Feat/ss/analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 # === Docker ===
 *.env
 docker-compose.override.yml
+*.sh
 
 # === OS files ===
 .DS_Store

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,43 @@
+# Air - Live reload for Go apps
+# https://github.com/air-verse/air
+
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  # Build command — compiles the API server
+  cmd = "go build -o ./tmp/api ./cmd/api/main.go"
+  # Binary to run after build
+  entrypoint = "./tmp/api"
+  # Watch these file extensions
+  include_ext = ["go", "toml", "yaml", "yml"]
+  # Exclude directories from watching
+  exclude_dir = ["tmp", "vendor", "node_modules", ".git"]
+  # Exclude files matching these patterns
+  exclude_file = []
+  # Exclude regex patterns
+  exclude_regex = ["_test.go"]
+  # Delay before rebuilding after a change (in ms)
+  delay = 1000
+  # Stop running old binary when build errors occur
+  stop_on_error = true
+  # Send interrupt signal before killing process
+  send_interrupt = true
+  # Delay after sending interrupt (in ms)
+  kill_delay = 500
+
+[log]
+  # Show log time
+  time = false
+  # Only show main log (silences watcher/build logs)
+  main_only = false
+
+[color]
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[misc]
+  # Delete tmp directory on exit
+  clean_on_exit = true

--- a/backend/.air.worker.toml
+++ b/backend/.air.worker.toml
@@ -1,0 +1,23 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/posteaze-worker ./cmd/worker"
+bin = "./tmp/posteaze-worker"
+kill_delay = 500
+include_ext = ["go"]
+exclude_dir = ["vendor", "tmp", "docs"]
+full_bin = ""
+
+[log]
+time = true
+
+[color]
+main = "cyan"
+watcher = "yellow"
+build = "green"
+runner = "magenta"
+
+[misc]
+clean_on_exit = true
+

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,13 @@
 # PostEaze Backend Makefile
 # Provides convenient commands for testing, building, and development
 
-.PHONY: help test test-unit test-integration test-coverage test-verbose test-race test-bench clean build run dev lint fmt vet deps
+# Air binary (can be overridden: `make dev AIR=/path/to/air`)
+AIR ?= air
+
+.PHONY: help test test-unit test-integration test-coverage test-verbose test-race test-bench clean build run dev dev-worker lint fmt vet deps tidy run-api run-worker build-api build-worker
+
+GOPATH ?= $(shell go env GOPATH)
+AIR = $(GOPATH)/bin/air
 
 # Default target
 help: ## Show this help message
@@ -157,6 +163,52 @@ test-sqlite: ## Run integration tests with SQLite
 test-postgres: ## Run integration tests with PostgreSQL
 	@echo "Running integration tests with PostgreSQL..."
 	@./scripts/test.sh --type integration --database postgres
+
+###############################################################################
+# ─── Development (hot-reload) ────────────────────────────────────────────────
+###############################################################################
+
+## Run the API server with Air live-reload
+dev:
+	$(AIR)
+
+## Run the asynq worker with Air live-reload
+dev-worker:
+	$(AIR) -c .air.worker.toml
+
+###############################################################################
+# ─── Development (no reload) ─────────────────────────────────────────────────
+###############################################################################
+
+## Run the API server directly
+run-api:
+	go run ./main.go
+
+## Run the asynq worker directly
+run-worker:
+	go run ./cmd/worker/main.go
+
+###############################################################################
+# ─── Build ───────────────────────────────────────────────────────────────────
+###############################################################################
+
+## Build both binaries
+build: build-api build-worker
+
+build-api:
+	go build -o bin/api ./main.go
+
+build-worker:
+	go build -o bin/worker ./cmd/worker/main.go
+
+###############################################################################
+# ─── Maintenance ─────────────────────────────────────────────────────────────
+###############################################################################
+
+## Tidy module dependencies
+tidy:
+	go mod tidy
+
 
 # Output format tests
 test-json: ## Run tests with JSON output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
     ports:
-      - "5432:5432"  # Exposed for team development access
+      - "5440:5432"  # Exposed for team development access (host 5433 → container 5432)
     networks:
       - posteaze
 
@@ -49,7 +49,7 @@ services:
     container_name: posteaze-redis
     restart: unless-stopped
     ports:
-      - "6379:6379"
+      - "6390:6379"
     networks:
       - posteaze
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes local development tooling/Makefile targets and remaps Postgres/Redis host ports in `docker-compose.yml`, which can break existing dev setups or scripts that assume default ports.
> 
> **Overview**
> Adds Air live-reload support for backend development by introducing `.air.toml` (API) and `.air.worker.toml` (worker) plus new Makefile targets for hot-reload (`dev`, `dev-worker`), direct runs (`run-api`, `run-worker`), builds (`build-api`, `build-worker`), and `go mod tidy`.
> 
> Updates local Docker port mappings for Postgres and Redis to non-default host ports, and expands `.gitignore` to ignore `*.sh` scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cb5caa8d1d7f9b1ecce6ad816d1641a79668c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->